### PR TITLE
メッセージにURLが含まれる場合、別のメッセージに置き換える

### DIFF
--- a/discord_tool_bot/events/Chat_Reading.js
+++ b/discord_tool_bot/events/Chat_Reading.js
@@ -30,9 +30,9 @@ module.exports = {
                 const message = `${interaction.content}`;// 受信したメッセージをいったん格納
                 
                 // URLが含まれているかチェック
-                if(message.match(regex_URL)) {
+                if(message.match(regex_URL) !== null) {
                     text = `${member.displayName}さんがURLを送信しました。`;
-                } else if(message.match(regex_UserId)) {
+                } else if(message.match(regex_UserId) !== null) {
                     // メンションしてたら、ユーザIDをユーザ名に置き換え
                     let receive_Message = message;
                     await message.match(regex_UserId).forEach(async get_UserId => {// forEachは非同期処理？みたいなのでawaitする

--- a/discord_tool_bot/events/Chat_Reading.js
+++ b/discord_tool_bot/events/Chat_Reading.js
@@ -26,8 +26,13 @@ module.exports = {
             } else {
                 // 読み上げテキストを作成
                 let regex_UserId = /<@[0-9]{17,19}>/g;// ユーザIdの正規表現
+                let regex_URL = /https?:\/\/[^\s]+/g;// URL検出用の正規表現
                 const message = `${interaction.content}`;// 受信したメッセージをいったん格納
-                if(regex_UserId.test(message)) {
+                
+                // URLが含まれているかチェック
+                if(regex_URL.test(message)) {
+                    text = `${member.displayName}さんがURLを送信しました。`;
+                } else if(regex_UserId.test(message)) {
                     // メンションしてたら、ユーザIDをユーザ名に置き換え
                     let receive_Message = message;
                     await message.match(regex_UserId).forEach(async get_UserId => {// forEachは非同期処理？みたいなのでawaitする

--- a/discord_tool_bot/events/Chat_Reading.js
+++ b/discord_tool_bot/events/Chat_Reading.js
@@ -26,7 +26,7 @@ module.exports = {
             } else {
                 // 読み上げテキストを作成
                 let regex_UserId = /<@[0-9]{17,19}>/g;// ユーザIdの正規表現
-                let regex_URL = /https?:\/\/[^\s]+/g;// URL検出用の正規表現
+                let regex_URL = /https?:\/\/(?:[-\w.])+(?::[0-9]+)?(?:\/(?:[\w\/_.])*(?:\?(?:[\w&=%.])*)?(?:#(?:[\w.])*)?)?/g;// URL検出用の正規表現
                 const message = `${interaction.content}`;// 受信したメッセージをいったん格納
                 
                 // URLが含まれているかチェック

--- a/discord_tool_bot/events/Chat_Reading.js
+++ b/discord_tool_bot/events/Chat_Reading.js
@@ -30,9 +30,9 @@ module.exports = {
                 const message = `${interaction.content}`;// 受信したメッセージをいったん格納
                 
                 // URLが含まれているかチェック
-                if(regex_URL.test(message)) {
+                if(message.match(regex_URL)) {
                     text = `${member.displayName}さんがURLを送信しました。`;
-                } else if(regex_UserId.test(message)) {
+                } else if(message.match(regex_UserId)) {
                     // メンションしてたら、ユーザIDをユーザ名に置き換え
                     let receive_Message = message;
                     await message.match(regex_UserId).forEach(async get_UserId => {// forEachは非同期処理？みたいなのでawaitする


### PR DESCRIPTION
メッセージにURLが含まれる場合、「〜〜さんがURLを送信しました。」という文に置き換える。

https://github.com/mendoitarou/Discord_Tool_Bot/issues/27