### PR TITLE
長過ぎるテキストを途中で切る

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ VOICEVOX_API_URL: https://api.ai.sakura.ad.jp/tts/v1
 
 また、`VOICEVOX_isAuth`を`true`に変更し、`VOICEVOX_API_TOKEN`にアカウントトークンを指定してください。
 
+```
+VOICEVOX_isAuth: true
+VOICEVOX_API_TOKEN: '~~~~~~~~~~~'
+```
+
 これだけで音声合成をさくらのAI Engineに任せることができます。
 
 ## 使用させていただいたもの

--- a/discord_tool_bot/commands/utility/chat_reading.js
+++ b/discord_tool_bot/commands/utility/chat_reading.js
@@ -132,7 +132,7 @@ module.exports = {
 				const resource = await voicevox.voicevox_generate_voice(text, VOICEVOX_Speaker_Id);
 				if (resource === "Error") return;
 				// ボイスチャットでの再生処理
-				player.play_resource(voicechannel_connection);
+				player.play_resource(voicechannel_connection, './output_'+resource+'.wav');
 
 				// メッセージ送信
 				await interaction.reply({ content: 'テスト音声を再生します。(生成あり)', flags: MessageFlags.Ephemeral });

--- a/discord_tool_bot/events/Chat_Reading.js
+++ b/discord_tool_bot/events/Chat_Reading.js
@@ -4,10 +4,22 @@ const fs = require('fs');
 const { Events } = require('discord.js');
 const { getVoiceConnection } = require('@discordjs/voice');
 
-const { guildId, Reading_Channel, If_Reding, Reading_Role_Id, VOICEVOX_Speaker_Id } = process.env;
+const { guildId, Reading_Channel, If_Reding, Reading_Role_Id, VOICEVOX_Speaker_Id, MAX_TEXT_LENGTH, Language } = process.env;
 
 const voicevox = require('../VOICEVOX.js');
 const player = require('../Playing_VoiceChannel.js');
+
+// Text Length
+function countGrapheme(string) {
+  const segmenter = new Intl.Segmenter(`${Language}`, { granularity: "grapheme" });
+  return [...segmenter.segment(string)].length;
+}
+
+function replaceText(text, max_length) {
+    const segmenter = new Intl.Segmenter(`${Language}`, { granularity: "grapheme" });
+    const segment_text = [...segmenter.segment(text)];
+    return segment_text.slice(0, max_length).join('');// 結合
+}
 
 // Queue
 const queues = new Map();
@@ -150,6 +162,7 @@ module.exports = {
                 } else {
                     // 普通にメッセージだったら
                     let receive_Message = message;
+                    receive_Message = receive_Message.replace(/\r?\n/g, '、');// 改行コードを「、」に変換
                     if(checkUserId(receive_Message)) {// ユーザIDチェック
                         receive_Message = await replaceUserId(receive_Message);
                     }
@@ -163,7 +176,11 @@ module.exports = {
                     if(checkMarkOnly(receive_Message)) {// 感嘆符/疑問符のみで構成されている
                         receive_Message = replaceBikkuri_QuestionMark(receive_Message);
                     }
-                    text = `${member.displayName}さんのメッセージ、${receive_Message.replace(/r?n/g, '、')}`;// 最終的なメッセージを指定
+                    // 文字数チェック
+                    if(countGrapheme > MAX_TEXT_LENGTH) {
+                        receive_Message = replaceText(receive_Message, MAX_TEXT_LENGTH) + '以下略';// 文字列を変換
+                    }
+                    text = `${member.displayName}さんのメッセージ、${receive_Message}`;// 最終的なメッセージを指定
                 }
                 console.log(`Text: ${text}`);
             }

--- a/discord_tool_bot/events/Chat_Reading.js
+++ b/discord_tool_bot/events/Chat_Reading.js
@@ -18,7 +18,7 @@ function countGrapheme(string) {
 function replaceText(text, max_length) {
     const segmenter = new Intl.Segmenter(`${Language}`, { granularity: "grapheme" });
     const segment_text = [...segmenter.segment(text)];
-    return segment_text.slice(0, max_length).join('');// 結合
+    return segment_text.slice(0, max_length).map(s => s.segment).join('');// 結合(segment_textはObjectなので、segmentを取り出して処理)
 }
 
 // Queue

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,17 +10,19 @@ services:
     depends_on:
       - voicevox
     environment:
-      DISCORD_BOT_TOKEN:
-      clientId:
-      guildId:
-      ownerId:
-      NOTIFY_CHANNEL:
-      Reading_Channel:
-      Reading_Role_Id:
-      Voice_Channel_Id:
+      DISCORD_BOT_TOKEN: 
+      clientId: 
+      guildId: 
+      ownerId: 
+      NOTIFY_CHANNEL: 
+      Reading_Channel: 
+      Reading_Role_Id: 
+      Voice_Channel_Id: 
       If_Reding: true
       If_Notify_Status_Voice_Channel: true
       VOICEVOX_API_URL: http://voicevox:50021
       VOICEVOX_Speaker_Id: 3
       VOICEVOX_isAuth: false
-      VOICEVOX_API_TOKEN:
+      VOICEVOX_API_TOKEN: ''
+      MAX_TEXT_LENGTH: 50
+      Language: ja-JP


### PR DESCRIPTION
長過ぎるテキストは途中で「以下略」と切る。
文字数は自分で決めれるようにしている。デフォルトは50文字。